### PR TITLE
Add `quit` or `exit` to interactive shell

### DIFF
--- a/src/process_file.cpp
+++ b/src/process_file.cpp
@@ -17,6 +17,8 @@
 
 namespace {
 
+using core::code::CodeToEdit;
+
 void print_program_info_(const Configurations &configs)
 {
     fmt::print("● FuncGraft ");
@@ -33,24 +35,6 @@ void print_program_info_(const Configurations &configs)
 
     fmt::print("● ");
     fmt::print(fg(fmt::color::yellow_green), "{}\n\n", configs.input_file.string());
-}
-
-using core::code::CodeToEdit;
-
-CodeToEdit import_file_to_edit_(const Configurations &configs)
-{
-    const std::string raw_text = utils::read_from_file(configs.input_file);
-
-    CodeToEdit content(raw_text);
-
-    if (content.is_delimited()) {
-        utils::print_separator();
-        fmt::print(fg(fmt::color::dim_gray), "@@@\n");
-        fmt::print(fg(fmt::terminal_color::bright_blue), "{}", content.get_original_code());
-        fmt::print(fg(fmt::color::dim_gray), "@@@\n");
-    }
-
-    return content;
 }
 
 std::string load_instructions_(const Configurations &configs)
@@ -103,6 +87,22 @@ bool validate_instructions_(const Configurations &configs, const std::string &in
         return false;
     },
         response);
+}
+
+CodeToEdit import_file_to_edit_(const Configurations &configs)
+{
+    const std::string raw_text = utils::read_from_file(configs.input_file);
+
+    CodeToEdit content(raw_text);
+
+    if (content.is_delimited()) {
+        utils::print_separator();
+        fmt::print(fg(fmt::color::dim_gray), "@@@\n");
+        fmt::print(fg(fmt::terminal_color::bright_blue), "{}", content.get_original_code());
+        fmt::print(fg(fmt::color::dim_gray), "@@@\n");
+    }
+
+    return content;
 }
 
 std::string create_prompt_(const Configurations &configs, const CodeToEdit &content, const std::string &instructions)
@@ -178,7 +178,6 @@ void process_file(const Configurations &configs)
 {
     print_program_info_(configs);
 
-    CodeToEdit content = import_file_to_edit_(configs);
     const std::string instructions = load_instructions_(configs);
 
     if (not validate_instructions_(configs, instructions)) {
@@ -186,6 +185,7 @@ void process_file(const Configurations &configs)
         return;
     }
 
+    CodeToEdit content = import_file_to_edit_(configs);
     const std::string prompt = create_prompt_(configs, content, instructions);
     const std::string modified_code = edit_text_using_llm_(configs, prompt);
 

--- a/src/process_file.cpp
+++ b/src/process_file.cpp
@@ -68,9 +68,10 @@ std::string load_instructions_(const Configurations &configs)
 
 bool check_for_special_command_(const std::string &instructions)
 {
-    if (instructions == "quit") {
-        return false;
-    } else if (instructions == "exit") {
+    if (instructions == "quit" or instructions == "exit") {
+#ifdef TESTING_ENABLED
+        fmt::print("Program aborted\n");
+#endif
         return false;
     }
 

--- a/src/process_file.cpp
+++ b/src/process_file.cpp
@@ -65,6 +65,17 @@ std::string load_instructions_(const Configurations &configs)
     return instructions;
 }
 
+bool check_for_special_command_(const std::string &instructions)
+{
+    if (instructions == "quit") {
+        return false;
+    } else if (instructions == "exit") {
+        return false;
+    }
+
+    return true;
+}
+
 bool validate_instructions_(const Configurations &configs, const std::string &instructions)
 {
     const std::string prompt = core::user_prompts::prompt_check_instructions(instructions);
@@ -179,6 +190,10 @@ void process_file(const Configurations &configs)
     print_program_info_(configs);
 
     const std::string instructions = load_instructions_(configs);
+
+    if (not check_for_special_command_(instructions)) {
+        return;
+    }
 
     if (not validate_instructions_(configs, instructions)) {
         utils::print_separator();

--- a/src/process_file.cpp
+++ b/src/process_file.cpp
@@ -40,6 +40,7 @@ void print_program_info_(const Configurations &configs)
 std::string load_instructions_(const Configurations &configs)
 {
     if (configs.instructions_from_cli) {
+        utils::print_separator();
         return configs.instructions_from_cli.value();
     }
 

--- a/src/process_file.cpp
+++ b/src/process_file.cpp
@@ -39,8 +39,9 @@ void print_program_info_(const Configurations &configs)
 
 std::string load_instructions_(const Configurations &configs)
 {
+    utils::print_separator();
+
     if (configs.instructions_from_cli) {
-        utils::print_separator();
         return configs.instructions_from_cli.value();
     }
 
@@ -50,7 +51,6 @@ std::string load_instructions_(const Configurations &configs)
         return utils::read_from_file(instructions_file);
     }
 
-    utils::print_separator();
     std::string instructions;
 
     while (true) {

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -146,7 +146,7 @@ def test_reject_unrelated_instructions(provider: str, file_to_edit: Path) -> Non
         "What is the weather in Phoenix, Arizona?",
         "Why did the dinosaurs go extinct?",
         "How to sew a canvas tool roll?",
-        "Who is the 32 Prime Minister of Canada?",
+        "Who is the 32nd Prime Minister of Canada?",
         "What is limit sell order?",
     ],
 )

--- a/tests/test_input_output_files.py
+++ b/tests/test_input_output_files.py
@@ -102,17 +102,17 @@ def main() -> None:
 
 
 def test_input_file_is_empty() -> None:
-    stderr = assert_command_failure("")
+    stderr = assert_command_failure("", "-i'Fix the null pointer exception'")
     assert "No filename was provided. Cannot proceed" in stderr
 
 
 def test_input_file_is_not_a_file() -> None:
-    stderr = assert_command_failure("/tmp", "-iFoo")
+    stderr = assert_command_failure("/tmp", "-i'Fix the null pointer exception'")
     assert "Input '/tmp' is not a file!" in stderr
 
 
 def test_input_file_is_missing() -> None:
-    stderr = assert_command_failure("abc.txt", "-iFoo")
+    stderr = assert_command_failure("abc.txt", "-i'Fix the null pointer exception'")
     assert "File 'abc.txt' does not exist!" in stderr
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -59,3 +59,11 @@ def test_empty_instructions_file(
 def test_empty_instructions(dummy_python_file: Path) -> None:
     stderr = assert_command_failure(f"{dummy_python_file}", "--instructions=")
     assert "CLI instructions are empty. Cannot proceed" in stderr
+
+
+@mark.parametrize("instruction", ["quit", "exit"])
+def test_exit_program(dummy_python_file: Path, instruction: str) -> None:
+    stdout = assert_command_success(
+        f"{dummy_python_file}", f"--instructions={instruction}"
+    )
+    assert "Program aborted" in stdout


### PR DESCRIPTION
Closes #62